### PR TITLE
Add security services

### DIFF
--- a/src/WorkshopBooker.Api/Program.cs
+++ b/src/WorkshopBooker.Api/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using WorkshopBooker.Infrastructure.Persistence;
 using WorkshopBooker.Application;
+using WorkshopBooker.Infrastructure;
+using WorkshopBooker.Infrastructure.Security;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +16,8 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 // Po linii z AddDbContext
 builder.Services.AddScoped<WorkshopBooker.Application.Common.Interfaces.IApplicationDbContext>(provider =>
     provider.GetRequiredService<WorkshopBooker.Infrastructure.Persistence.ApplicationDbContext>());
+builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("JwtSettings"));
+builder.Services.AddInfrastructure();
 // Dla MediatR (po utworzeniu IApplicationMarker)
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(WorkshopBooker.Application.IApplicationMarker).Assembly));
 // -----------------------------------------------------------
@@ -26,7 +30,7 @@ builder.Services.AddCors(options =>
               .AllowAnyMethod();
     });
 });
-builder.Services.AddControllers(); // Dodaj tê liniê
+builder.Services.AddControllers(); // Dodaj tÃª liniÃª
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -42,9 +46,9 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseCors("AllowDevelopmentClients");
 
-app.UseRouting(); // Dodaj tê liniê
-app.UseAuthorization(); // Dodaj tê liniê
+app.UseRouting(); // Dodaj tÃª liniÃª
+app.UseAuthorization(); // Dodaj tÃª liniÃª
 
-app.MapControllers(); // Dodaj tê liniê zamiast kodu weatherforecast
+app.MapControllers(); // Dodaj tÃª liniÃª zamiast kodu weatherforecast
 
 app.Run();

--- a/src/WorkshopBooker.Api/appsettings.json
+++ b/src/WorkshopBooker.Api/appsettings.json
@@ -6,4 +6,11 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "JwtSettings": {
+    "Secret": "J92MHBaNio4Pn9h7GrZZPMzvWEY42XJJNVbmI1JCjB8=",
+    "ExpiryMinutes": 60,
+    "Issuer": "WorkshopBooker.Api",
+    "Audience": "WorkshopBooker.Api"
+  }
 }

--- a/src/WorkshopBooker.Application/Common/Interfaces/IJwtTokenGenerator.cs
+++ b/src/WorkshopBooker.Application/Common/Interfaces/IJwtTokenGenerator.cs
@@ -1,0 +1,8 @@
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Common.Interfaces;
+
+public interface IJwtTokenGenerator
+{
+    string GenerateToken(User user);
+}

--- a/src/WorkshopBooker.Application/Common/Interfaces/IPasswordHasher.cs
+++ b/src/WorkshopBooker.Application/Common/Interfaces/IPasswordHasher.cs
@@ -1,0 +1,7 @@
+namespace WorkshopBooker.Application.Common.Interfaces;
+
+public interface IPasswordHasher
+{
+    string Hash(string password);
+    bool Verify(string password, string hashedPassword);
+}

--- a/src/WorkshopBooker.Infrastructure/DependencyInjection.cs
+++ b/src/WorkshopBooker.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using WorkshopBooker.Application.Common.Interfaces;
+using WorkshopBooker.Infrastructure.Security;
+
+namespace WorkshopBooker.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    {
+        services.AddSingleton<IPasswordHasher, PasswordHasher>();
+        services.AddSingleton<IJwtTokenGenerator, JwtTokenGenerator>();
+        return services;
+    }
+}

--- a/src/WorkshopBooker.Infrastructure/Security/JwtSettings.cs
+++ b/src/WorkshopBooker.Infrastructure/Security/JwtSettings.cs
@@ -1,0 +1,9 @@
+namespace WorkshopBooker.Infrastructure.Security;
+
+public class JwtSettings
+{
+    public string Secret { get; set; } = string.Empty;
+    public int ExpiryMinutes { get; set; }
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+}

--- a/src/WorkshopBooker.Infrastructure/Security/JwtTokenGenerator.cs
+++ b/src/WorkshopBooker.Infrastructure/Security/JwtTokenGenerator.cs
@@ -1,0 +1,44 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using WorkshopBooker.Application.Common.Interfaces;
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Infrastructure.Security;
+
+public class JwtTokenGenerator : IJwtTokenGenerator
+{
+    private readonly JwtSettings _jwtSettings;
+
+    public JwtTokenGenerator(IOptions<JwtSettings> jwtOptions)
+    {
+        _jwtSettings = jwtOptions.Value;
+    }
+
+    public string GenerateToken(User user)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(ClaimTypes.Role, user.Role),
+            new(JwtRegisteredClaimNames.Email, user.Email)
+        };
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Secret));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            Expires = DateTime.UtcNow.AddMinutes(_jwtSettings.ExpiryMinutes),
+            SigningCredentials = creds,
+            Issuer = _jwtSettings.Issuer,
+            Audience = _jwtSettings.Audience
+        };
+
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.CreateToken(tokenDescriptor);
+        return handler.WriteToken(token);
+    }
+}

--- a/src/WorkshopBooker.Infrastructure/Security/PasswordHasher.cs
+++ b/src/WorkshopBooker.Infrastructure/Security/PasswordHasher.cs
@@ -1,0 +1,16 @@
+using WorkshopBooker.Application.Common.Interfaces;
+
+namespace WorkshopBooker.Infrastructure.Security;
+
+public class PasswordHasher : IPasswordHasher
+{
+    public string Hash(string password)
+    {
+        return BCrypt.Net.BCrypt.HashPassword(password);
+    }
+
+    public bool Verify(string password, string hashedPassword)
+    {
+        return BCrypt.Net.BCrypt.Verify(password, hashedPassword);
+    }
+}

--- a/src/WorkshopBooker.Infrastructure/WorkshopBooker.Infrastructure.csproj
+++ b/src/WorkshopBooker.Infrastructure/WorkshopBooker.Infrastructure.csproj
@@ -5,12 +5,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- create `IPasswordHasher` and `IJwtTokenGenerator` interfaces
- implement `PasswordHasher` using BCrypt
- implement JWT generation with `JwtTokenGenerator` and `JwtSettings`
- register services in infrastructure
- expose configuration via `JwtSettings` section
- wire up DI in Program

## Testing
- `dotnet restore WorkshopBooker.sln`
- `dotnet build WorkshopBooker.sln -c Release`
- `dotnet test WorkshopBooker.sln`

------
https://chatgpt.com/codex/tasks/task_e_686062e6dbf4832792b86ecd32c0f245