### PR TITLE
Implement user registration

### DIFF
--- a/src/WorkshopBooker.Api/Controllers/AuthController.cs
+++ b/src/WorkshopBooker.Api/Controllers/AuthController.cs
@@ -1,0 +1,25 @@
+// src/WorkshopBooker.Api/Controllers/AuthController.cs
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using WorkshopBooker.Application.Auth.Commands.Register;
+
+namespace WorkshopBooker.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    public AuthController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterUserCommand command)
+    {
+        await _sender.Send(command);
+        return Ok();
+    }
+}

--- a/src/WorkshopBooker.Application/Auth/Commands/Register/RegisterUserCommand.cs
+++ b/src/WorkshopBooker.Application/Auth/Commands/Register/RegisterUserCommand.cs
@@ -1,0 +1,11 @@
+// src/WorkshopBooker.Application/Auth/Commands/Register/RegisterUserCommand.cs
+using MediatR;
+
+namespace WorkshopBooker.Application.Auth.Commands.Register;
+
+/// <summary>
+/// Command to register a new user.
+/// </summary>
+/// <param name="Email">User email address.</param>
+/// <param name="Password">User password.</param>
+public record RegisterUserCommand(string Email, string Password) : IRequest;

--- a/src/WorkshopBooker.Application/Auth/Commands/Register/RegisterUserCommandHandler.cs
+++ b/src/WorkshopBooker.Application/Auth/Commands/Register/RegisterUserCommandHandler.cs
@@ -1,0 +1,34 @@
+// src/WorkshopBooker.Application/Auth/Commands/Register/RegisterUserCommandHandler.cs
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WorkshopBooker.Application.Common.Interfaces;
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Auth.Commands.Register;
+
+public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IPasswordHasher _passwordHasher;
+
+    public RegisterUserCommandHandler(IApplicationDbContext context, IPasswordHasher passwordHasher)
+    {
+        _context = context;
+        _passwordHasher = passwordHasher;
+    }
+
+    public async Task Handle(RegisterUserCommand request, CancellationToken cancellationToken)
+    {
+        var emailExists = await _context.Users
+            .AnyAsync(u => u.Email == request.Email, cancellationToken);
+        if (emailExists)
+        {
+            throw new Exception("Email already exists.");
+        }
+
+        var hashedPassword = _passwordHasher.Hash(request.Password);
+        var user = new User(Guid.NewGuid(), request.Email, hashedPassword, "Client");
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- create RegisterUserCommand and handler
- add AuthController with register endpoint
- use password hasher and database context to add new user

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686064b65c608327959e7aafabf8764e