### PR TITLE
Implement login endpoint with JWT

### DIFF
--- a/src/WorkshopBooker.Api/Controllers/AuthController.cs
+++ b/src/WorkshopBooker.Api/Controllers/AuthController.cs
@@ -2,6 +2,8 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using WorkshopBooker.Application.Auth.Commands.Register;
+using WorkshopBooker.Application.Auth.Dtos;
+using WorkshopBooker.Application.Auth.Queries.Login;
 
 namespace WorkshopBooker.Api.Controllers;
 
@@ -21,5 +23,13 @@ public class AuthController : ControllerBase
     {
         await _sender.Send(command);
         return Ok();
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginQuery query)
+    {
+        var token = await _sender.Send(query);
+        var response = new AuthResponse(token);
+        return Ok(response);
     }
 }

--- a/src/WorkshopBooker.Application/Auth/Dtos/AuthResponse.cs
+++ b/src/WorkshopBooker.Application/Auth/Dtos/AuthResponse.cs
@@ -1,0 +1,4 @@
+// src/WorkshopBooker.Application/Auth/Dtos/AuthResponse.cs
+namespace WorkshopBooker.Application.Auth.Dtos;
+
+public record AuthResponse(string Token);

--- a/src/WorkshopBooker.Application/Auth/Queries/Login/LoginQuery.cs
+++ b/src/WorkshopBooker.Application/Auth/Queries/Login/LoginQuery.cs
@@ -1,0 +1,11 @@
+// src/WorkshopBooker.Application/Auth/Queries/Login/LoginQuery.cs
+using MediatR;
+
+namespace WorkshopBooker.Application.Auth.Queries.Login;
+
+/// <summary>
+/// Query used to authenticate a user and obtain JWT token.
+/// </summary>
+/// <param name="Email">User email.</param>
+/// <param name="Password">User password.</param>
+public record LoginQuery(string Email, string Password) : IRequest<string>;

--- a/src/WorkshopBooker.Application/Auth/Queries/Login/LoginQueryHandler.cs
+++ b/src/WorkshopBooker.Application/Auth/Queries/Login/LoginQueryHandler.cs
@@ -1,0 +1,37 @@
+// src/WorkshopBooker.Application/Auth/Queries/Login/LoginQueryHandler.cs
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WorkshopBooker.Application.Common.Interfaces;
+
+namespace WorkshopBooker.Application.Auth.Queries.Login;
+
+public class LoginQueryHandler : IRequestHandler<LoginQuery, string>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly IJwtTokenGenerator _tokenGenerator;
+
+    public LoginQueryHandler(
+        IApplicationDbContext context,
+        IPasswordHasher passwordHasher,
+        IJwtTokenGenerator tokenGenerator)
+    {
+        _context = context;
+        _passwordHasher = passwordHasher;
+        _tokenGenerator = tokenGenerator;
+    }
+
+    public async Task<string> Handle(LoginQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .FirstOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
+
+        if (user is null || !_passwordHasher.Verify(request.Password, user.HashedPassword))
+        {
+            throw new Exception("Invalid email or password.");
+        }
+
+        var token = _tokenGenerator.GenerateToken(user);
+        return token;
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO for auth responses
- add LoginQuery and LoginQueryHandler for user authentication
- expose POST /api/auth/login endpoint

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606739823c8327a5fcf81b1b1c1aee