### PR TITLE
Secure booking creation with JWT auth

### DIFF
--- a/src/WorkshopBooker.Api/Controllers/BookingsController.cs
+++ b/src/WorkshopBooker.Api/Controllers/BookingsController.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using WorkshopBooker.Application.Bookings.Commands.CreateBooking;
 using WorkshopBooker.Application.Bookings.Dtos;
 using WorkshopBooker.Application.Bookings.Queries.GetBookingsForWorkshop;
@@ -18,6 +19,7 @@ public class BookingsController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize]
     public async Task<IActionResult> Create(Guid serviceId, CreateBookingCommand command)
     {
         var fullCommand = command with { ServiceId = serviceId };

--- a/src/WorkshopBooker.Api/Program.cs
+++ b/src/WorkshopBooker.Api/Program.cs
@@ -1,4 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using WorkshopBooker.Infrastructure.Persistence;
 using WorkshopBooker.Application;
 using WorkshopBooker.Infrastructure;
@@ -31,6 +34,21 @@ builder.Services.AddCors(options =>
     });
 });
 builder.Services.AddControllers(); // Dodaj tê liniê
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["JwtSettings:Issuer"],
+            ValidAudience = builder.Configuration["JwtSettings:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(builder.Configuration["JwtSettings:Secret"]!))
+        };
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -47,6 +65,7 @@ app.UseHttpsRedirection();
 app.UseCors("AllowDevelopmentClients");
 
 app.UseRouting(); // Dodaj tê liniê
+app.UseAuthentication();
 app.UseAuthorization(); // Dodaj tê liniê
 
 app.MapControllers(); // Dodaj tê liniê zamiast kodu weatherforecast

--- a/src/WorkshopBooker.Api/WorkshopBooker.Api.csproj
+++ b/src/WorkshopBooker.Api/WorkshopBooker.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- add JWT auth packages and middleware
- secure bookings creation endpoint

## Testing
- `dotnet build WorkshopBooker.sln`

------
https://chatgpt.com/codex/tasks/task_e_6860f1ded76883278390faafb1238412