### PR TITLE
Fix service queries and booking race conditions

### DIFF
--- a/src/WorkshopBooker.Application/Slots/Queries/GetAvailableSlots/GetAvailableSlotsQueryHandler.cs
+++ b/src/WorkshopBooker.Application/Slots/Queries/GetAvailableSlots/GetAvailableSlotsQueryHandler.cs
@@ -16,7 +16,8 @@ public class GetAvailableSlotsQueryHandler : IRequestHandler<GetAvailableSlotsQu
 
     public async Task<List<AvailableSlotDto>> Handle(GetAvailableSlotsQuery request, CancellationToken cancellationToken)
     {
-        var service = await _context.Services.FirstOrDefaultAsync(s => s.Id == request.ServiceId, cancellationToken);
+        var service = await _context.Services
+            .FirstOrDefaultAsync(s => s.Id == request.ServiceId && s.WorkshopId == request.WorkshopId, cancellationToken);
         if (service == null)
         {
             return new List<AvailableSlotDto>();


### PR DESCRIPTION
## Summary
- avoid booking race conditions by re-checking slot availability and failing gracefully
- send booking confirmation using a single service fetch
- ensure available slot lookup validates service-workshop relation

## Testing
- `dotnet restore WorkshopBooker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb5c255808327b20e42b92bc412ce