### PR TITLE
Fix missing client directives in booking modal

### DIFF
--- a/frontend/client/src/app/components/EnhancedBookingModal.tsx
+++ b/frontend/client/src/app/components/EnhancedBookingModal.tsx
@@ -96,66 +96,65 @@ export const EnhancedBookingModal: React.FC<EnhancedBookingModalProps> = ({
 
   if (!isOpen) return null;
 
-  return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        {/* Background overlay */}
-        <div 
-          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
-          onClick={onClose}
-        />
-
-        {/* Modal panel */}
-        <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
-          {/* Header */}
-          <div className="bg-white px-6 py-4 border-b border-gray-200">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-4">
-                {/* Progress indicator */}
-                <div className="flex items-center space-x-2">
-                  <div className="flex items-center">
-                    <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
-                      getStepNumber() >= 1 ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'
-                    }`}>
-                      1
-                    </div>
-                    <div className={`w-8 h-1 ${
-                      getStepNumber() >= 2 ? 'bg-blue-600' : 'bg-gray-200'
-                    }`} />
-                    <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
-                      getStepNumber() >= 2 ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'
-                    }`}>
-                      2
-                    </div>
-                    <div className={`w-8 h-1 ${
-                      getStepNumber() >= 3 ? 'bg-blue-600' : 'bg-gray-200'
-                    }`} />
-                    <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
-                      getStepNumber() >= 3 ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'
-                    }`}>
-                      3
-                    </div>
-                  </div>
+return (
+  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    {/* Background overlay */}
+    <div 
+      className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+      onClick={onClose}
+    />
+    
+    {/* Modal panel */}
+    <div className="relative z-10 bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+      {/* Header */}
+      <div className="bg-white px-6 py-4 border-b border-gray-200">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-4">
+            {/* Progress indicator */}
+            <div className="flex items-center space-x-2">
+              <div className="flex items-center">
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+                  getStepNumber() >= 1 ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'
+                }`}>
+                  1
                 </div>
-                
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    {getStepTitle()}
-                  </h3>
-                  <p className="text-sm text-gray-600">
-                    {serviceName}
-                  </p>
+                <div className={`w-8 h-1 ${
+                  getStepNumber() >= 2 ? 'bg-blue-600' : 'bg-gray-200'
+                }`} />
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+                  getStepNumber() >= 2 ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'
+                }`}>
+                  2
+                </div>
+                <div className={`w-8 h-1 ${
+                  getStepNumber() >= 3 ? 'bg-blue-600' : 'bg-gray-200'
+                }`} />
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+                  getStepNumber() >= 3 ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'
+                }`}>
+                  3
                 </div>
               </div>
-              
-              <button
-                onClick={onClose}
-                className="text-gray-400 hover:text-gray-600 transition-colors"
-              >
-                <X className="h-6 w-6" />
-              </button>
+            </div>
+            
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">
+                {getStepTitle()}
+              </h3>
+              <p className="text-sm text-gray-600">
+                {serviceName}
+              </p>
             </div>
           </div>
+          
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="h-6 w-6" />
+          </button>
+        </div>
+      </div>
 
           {/* Content */}
           <div className="px-6 py-6">
@@ -256,6 +255,5 @@ export const EnhancedBookingModal: React.FC<EnhancedBookingModalProps> = ({
           </div>
         </div>
       </div>
-    </div>
   );
 }; 

--- a/frontend/client/src/app/components/EnhancedBookingModal.tsx
+++ b/frontend/client/src/app/components/EnhancedBookingModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from 'react';
 import { X, ChevronLeft, ChevronRight, Calendar } from 'lucide-react';
 import { useBookingFlow } from '../../hooks/useBookingFlow';

--- a/frontend/client/src/app/components/booking/CalendarView.tsx
+++ b/frontend/client/src/app/components/booking/CalendarView.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { Calendar, Clock, Zap, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Slot } from '../../../hooks/useBookingFlow';

--- a/frontend/client/src/app/components/booking/ConfirmationView.tsx
+++ b/frontend/client/src/app/components/booking/ConfirmationView.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { CheckCircle, Calendar, Clock, Mail, ArrowRight, Home } from 'lucide-react';
 import { Slot, BookingFormData } from '../../../hooks/useBookingFlow';

--- a/frontend/client/src/app/components/booking/FormView.tsx
+++ b/frontend/client/src/app/components/booking/FormView.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { ArrowLeft, User, Mail, Phone, FileText, Calendar, Clock } from 'lucide-react';
 import { Slot, BookingFormData } from '../../../hooks/useBookingFlow';


### PR DESCRIPTION
## Summary
- mark all booking modal components with `"use client"` so Next.js treats them as client components

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c424313f48327874f2dffcfb8ff51