### PR TITLE
Add DevOps Docker and Kubernetes setup

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main, feature/** ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore
+        run: dotnet restore WorkshopBooker.sln
+      - name: Build
+        run: dotnet build --no-restore WorkshopBooker.sln
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install frontend deps
+        run: npm install --prefix frontend/client
+      - name: Lint frontend
+        run: npm run lint --prefix frontend/client

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Build images
+        run: docker-compose -f docker-compose.yml build
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: v1.29.0
+      - name: Deploy manifests
+        run: kubectl apply -f k8s/

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  workshop-service:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    command: ["dotnet", "watch", "--project", "WorkshopBooker.Api/WorkshopBooker.Api.csproj"]
+
+  emergency-service:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    command: ["dotnet", "watch", "--project", "WorkshopBooker.Api/WorkshopBooker.Api.csproj"]
+
+  web-app:
+    command: ["npm", "run", "dev"]
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8088

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,11 @@ services:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   pgadmin:
     image: dpage/pgadmin4:latest
@@ -23,7 +27,76 @@ services:
     ports:
       - "8080:80"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+
+  workshop-service:
+    image: mcr.microsoft.com/dotnet/sdk:8.0
+    container_name: workshop-service
+    working_dir: /src
+    command: ["dotnet", "run", "--urls", "http://0.0.0.0:80", "--project", "WorkshopBooker.Api/WorkshopBooker.Api.csproj"]
+    volumes:
+      - ./src:/src
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__DefaultConnection: Server=postgres;Port=5432;Database=WorkshopDb;User Id=postgres;Password=twoje_haslo;
+    ports:
+      - "5000:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  emergency-service:
+    image: mcr.microsoft.com/dotnet/sdk:8.0
+    container_name: emergency-service
+    working_dir: /src
+    command: ["dotnet", "run", "--urls", "http://0.0.0.0:80", "--project", "WorkshopBooker.Api/WorkshopBooker.Api.csproj"]
+    volumes:
+      - ./src:/src
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__DefaultConnection: Server=postgres;Port=5432;Database=EmergencyDb;User Id=postgres;Password=twoje_haslo;
+    ports:
+      - "5001:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  api-gateway:
+    image: nginx:alpine
+    container_name: api-gateway
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8088:80"
+    depends_on:
+      workshop-service:
+        condition: service_started
+      emergency-service:
+        condition: service_started
+
+  web-app:
+    image: node:18
+    container_name: web-app
+    working_dir: /app
+    command: ["npm", "run", "dev"]
+    volumes:
+      - ./frontend/client:/app
+    environment:
+      NEXT_PUBLIC_API_URL: http://api-gateway
+    ports:
+      - "3000:3000"
+    depends_on:
+      api-gateway:
+        condition: service_started
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
 
 volumes:
   postgres_data:

--- a/k8s/api-gateway-deployment.yml
+++ b/k8s/api-gateway-deployment.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: api-gateway
+          image: nginx:alpine
+          ports:
+            - containerPort: 80

--- a/k8s/emergency-service-deployment.yml
+++ b/k8s/emergency-service-deployment.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: emergency-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emergency-service
+  template:
+    metadata:
+      labels:
+        app: emergency-service
+    spec:
+      containers:
+        - name: emergency-service
+          image: ghcr.io/workshopbooker/emergency-service:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Production

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: workshopbooker-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-app
+                port:
+                  number: 3000

--- a/k8s/services.yml
+++ b/k8s/services.yml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emergency-service
+spec:
+  selector:
+    app: emergency-service
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workshop-service
+spec:
+  selector:
+    app: workshop-service
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-app
+spec:
+  selector:
+    app: web-app
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'workshop-service'
+    static_configs:
+      - targets: ['workshop-service:80']
+  - job_name: 'emergency-service'
+    static_configs:
+      - targets: ['emergency-service:80']

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+kubectl apply -f k8s/services.yml
+kubectl apply -f k8s/api-gateway-deployment.yml
+kubectl apply -f k8s/emergency-service-deployment.yml
+kubectl apply -f k8s/ingress.yml

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Starting WorkshopBooker stack..."
+docker-compose pull
+docker-compose up -d


### PR DESCRIPTION
## Summary
- add docker compose stack for local dev
- provide override for development values
- create Kubernetes manifests for gateway and services
- add basic GitHub Actions pipelines
- include helper scripts for starting and deploying
- add Prometheus config for monitoring

## Testing
- `dotnet build WorkshopBooker.sln` *(fails: command not found)*
- `npm run lint` *(fails: lint errors)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee0325244832784faeb6324e61e5e