### PR TITLE
Add BFF integration hooks and components

### DIFF
--- a/frontend/admin/src/hooks/useEmergencyService.ts
+++ b/frontend/admin/src/hooks/useEmergencyService.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query'
+import { callService } from '../services/microserviceClient'
+
+export const useEmergencyService = () => {
+  return useMutation({
+    mutationFn: async (payload: any) =>
+      await callService('emergency', '/request', { method: 'POST', data: payload }),
+  })
+}

--- a/frontend/admin/src/hooks/useMicroserviceHealth.ts
+++ b/frontend/admin/src/hooks/useMicroserviceHealth.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { callService } from '../services/microserviceClient'
+
+export const useMicroserviceHealth = (service: string) => {
+  return useQuery(['service-health', service], async () => {
+    return await callService(service, '/health', { method: 'GET' })
+  }, {
+    retry: false
+  })
+}

--- a/frontend/admin/src/pages/api/emergency/[...params].ts
+++ b/frontend/admin/src/pages/api/emergency/[...params].ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import apiGateway from '../../../services/apiGateway'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query
+  const path = Array.isArray(params) ? params.join('/') : params
+
+  try {
+    const response = await apiGateway.request({
+      url: `/api/emergency/${path}`,
+      method: req.method as any,
+      data: req.body,
+      params: req.query
+    })
+    res.status(response.status).json(response.data)
+  } catch (error: any) {
+    if (error.response) {
+      res.status(error.response.status).json(error.response.data)
+    } else {
+      res.status(500).json({ message: 'Gateway unavailable' })
+    }
+  }
+}

--- a/frontend/admin/src/pages/api/workshops/[...params].ts
+++ b/frontend/admin/src/pages/api/workshops/[...params].ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import apiGateway from '../../../services/apiGateway'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query
+  const path = Array.isArray(params) ? params.join('/') : params
+
+  try {
+    const response = await apiGateway.request({
+      url: `/api/workshops/${path}`,
+      method: req.method as any,
+      data: req.body,
+      params: req.query
+    })
+    res.status(response.status).json(response.data)
+  } catch (error: any) {
+    if (error.response) {
+      res.status(error.response.status).json(error.response.data)
+    } else {
+      res.status(500).json({ message: 'Gateway unavailable' })
+    }
+  }
+}

--- a/frontend/admin/src/services/apiGateway.ts
+++ b/frontend/admin/src/services/apiGateway.ts
@@ -1,0 +1,22 @@
+import axios from 'axios'
+
+const apiGateway = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_GATEWAY_URL || 'http://localhost:8080',
+  headers: {
+    'Content-Type': 'application/json'
+  }
+})
+
+apiGateway.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    if (error.response) {
+      console.error('API Gateway error:', error.response.status)
+    } else {
+      console.error('API Gateway unavailable')
+    }
+    return Promise.reject(error)
+  }
+)
+
+export default apiGateway

--- a/frontend/admin/src/services/microserviceClient.ts
+++ b/frontend/admin/src/services/microserviceClient.ts
@@ -1,0 +1,16 @@
+import apiGateway from './apiGateway'
+
+export async function callService(service: string, path: string, options: any = {}) {
+  try {
+    const response = await apiGateway.request({
+      url: `/${service}${path}`,
+      ...options
+    })
+    return response.data
+  } catch (error: any) {
+    if (error.response) {
+      throw new Error(error.response.data?.message || 'Service error')
+    }
+    throw new Error('Service unavailable')
+  }
+}

--- a/frontend/client/src/apiGateway.ts
+++ b/frontend/client/src/apiGateway.ts
@@ -1,0 +1,20 @@
+import axios from 'axios'
+
+const apiGateway = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_GATEWAY_URL || 'http://localhost:8080',
+  headers: { 'Content-Type': 'application/json' }
+})
+
+apiGateway.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    if (error.response) {
+      console.error('API Gateway error:', error.response.status)
+    } else {
+      console.error('API Gateway unavailable')
+    }
+    return Promise.reject(error)
+  }
+)
+
+export default apiGateway

--- a/frontend/client/src/components/EmergencyBooking/index.tsx
+++ b/frontend/client/src/components/EmergencyBooking/index.tsx
@@ -1,0 +1,35 @@
+'use client'
+import React, { useState } from 'react'
+import axios from 'axios'
+
+export const EmergencyBooking: React.FC = () => {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  const requestHelp = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      await axios.post('/api/emergency/request')
+      setSuccess(true)
+    } catch (err) {
+      setError('Service unavailable')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (loading) return <div className="animate-pulse h-10 bg-gray-200 rounded" />
+  if (success) return <p className="text-green-600">Request sent!</p>
+
+  return (
+    <div className="space-y-2">
+      {error && <p className="text-red-500">{error}</p>}
+      <button onClick={requestHelp} className="px-4 py-2 bg-blue-600 text-white rounded">
+        Call Emergency Service
+      </button>
+    </div>
+  )
+}
+export default EmergencyBooking

--- a/frontend/client/src/components/ServiceHealthStatus/index.tsx
+++ b/frontend/client/src/components/ServiceHealthStatus/index.tsx
@@ -1,0 +1,17 @@
+'use client'
+import React from 'react'
+import useSWR from 'swr'
+import axios from 'axios'
+
+const fetcher = (url: string) => axios.get(url).then(r => r.data)
+
+export const ServiceHealthStatus: React.FC<{ service: string }> = ({ service }) => {
+  const { data, error, isLoading } = useSWR(`/api/${service}/health`, fetcher, { refreshInterval: 30000 })
+
+  if (isLoading) return <div className="animate-pulse h-4 bg-gray-200 rounded w-20" />
+  if (error) return <span className="text-red-500">offline</span>
+
+  return <span className="text-green-600">{data?.status ?? 'online'}</span>
+}
+
+export default ServiceHealthStatus

--- a/frontend/client/src/pages/api/emergency/[...params].ts
+++ b/frontend/client/src/pages/api/emergency/[...params].ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import apiGateway from '../../../apiGateway'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query
+  const path = Array.isArray(params) ? params.join('/') : params
+  try {
+    const response = await apiGateway.request({
+      url: `/api/emergency/${path}`,
+      method: req.method as any,
+      data: req.body,
+      params: req.query
+    })
+    res.status(response.status).json(response.data)
+  } catch (error: any) {
+    if (error.response) {
+      res.status(error.response.status).json(error.response.data)
+    } else {
+      res.status(500).json({ message: 'Gateway unavailable' })
+    }
+  }
+}

--- a/frontend/client/src/pages/api/workshops/[...params].ts
+++ b/frontend/client/src/pages/api/workshops/[...params].ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import apiGateway from '../../../apiGateway'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query
+  const path = Array.isArray(params) ? params.join('/') : params
+  try {
+    const response = await apiGateway.request({
+      url: `/api/workshops/${path}`,
+      method: req.method as any,
+      data: req.body,
+      params: req.query
+    })
+    res.status(response.status).json(response.data)
+  } catch (error: any) {
+    if (error.response) {
+      res.status(error.response.status).json(error.response.data)
+    } else {
+      res.status(500).json({ message: 'Gateway unavailable' })
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- provide proxy API routes under admin and client apps
- add API gateway helper modules
- implement hooks for emergency and service health
- add client components for emergency booking and service health status

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test --silent` in `frontend/admin` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee0692f70832782b52138b20c1591