### PR TITLE
Integrate frontend BFF routes

### DIFF
--- a/frontend/admin/src/api/axiosConfig.ts
+++ b/frontend/admin/src/api/axiosConfig.ts
@@ -9,7 +9,7 @@ const showRateLimitNotification = (info: any) => {
 
 // Ustawiam prawidłowy adres API - port 5197 jest poprawny zgodnie z konfiguracją backendu
 const apiClient = axios.create({
-  baseURL: 'http://localhost:5197',
+  baseURL: process.env.NEXT_PUBLIC_API_GATEWAY_URL || '/api',
   headers: {
     'Content-Type': 'application/json'
   }

--- a/frontend/admin/src/hooks/useEmergencyService.ts
+++ b/frontend/admin/src/hooks/useEmergencyService.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { callMicroservice } from '../services/microserviceClient'
+
+type EmergencyRequest = {
+  description: string
+  location: string
+}
+
+export const useEmergencyService = () => {
+  const operators = useQuery(['emergency-operators'], () =>
+    callMicroservice<any[]>('/api/emergency/operators', { method: 'GET' })
+  )
+
+  const requestAssist = useMutation((payload: EmergencyRequest) =>
+    callMicroservice('/api/emergency/requests', { method: 'POST', data: payload })
+  )
+
+  return { operators, requestAssist }
+}

--- a/frontend/admin/src/hooks/useMicroserviceHealth.ts
+++ b/frontend/admin/src/hooks/useMicroserviceHealth.ts
@@ -1,0 +1,7 @@
+import { useQuery } from '@tanstack/react-query'
+import { checkServiceHealth } from '../services/microserviceClient'
+
+export const useMicroserviceHealth = (service: string) =>
+  useQuery(['service-health', service], () => checkServiceHealth(service), {
+    retry: false
+  })

--- a/frontend/admin/src/pages/api/emergency/[...params].ts
+++ b/frontend/admin/src/pages/api/emergency/[...params].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/emergency/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}

--- a/frontend/admin/src/pages/api/workshops/[...params].ts
+++ b/frontend/admin/src/pages/api/workshops/[...params].ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/workshops/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}

--- a/frontend/admin/src/services/apiGateway.ts
+++ b/frontend/admin/src/services/apiGateway.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+const baseURL = process.env.NEXT_PUBLIC_API_GATEWAY_URL || '/api'
+
+const apiGateway = axios.create({
+  baseURL,
+  headers: {
+    'Content-Type': 'application/json'
+  }
+})
+
+export default apiGateway

--- a/frontend/admin/src/services/microserviceClient.ts
+++ b/frontend/admin/src/services/microserviceClient.ts
@@ -1,0 +1,23 @@
+import type { AxiosRequestConfig } from 'axios'
+import apiGateway from './apiGateway'
+
+export async function callMicroservice<T>(path: string, options: AxiosRequestConfig = {}): Promise<T> {
+  try {
+    const response = await apiGateway.request<T>({ url: path, ...options })
+    return response.data
+  } catch (error: any) {
+    if (!error.response) {
+      throw new Error('Service unavailable')
+    }
+    throw error
+  }
+}
+
+export async function checkServiceHealth(service: string): Promise<boolean> {
+  try {
+    await apiGateway.get(`/api/${service}/health`)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/client/src/api/axiosConfig.ts
+++ b/frontend/client/src/api/axiosConfig.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 // Tworzymy instancję axios z domyślną konfiguracją
 const apiClient = axios.create({
-  baseURL: 'http://localhost:5197',
+  baseURL: process.env.NEXT_PUBLIC_API_GATEWAY_URL || '/api',
   headers: {
     'Content-Type': 'application/json'
   }

--- a/frontend/client/src/components/EmergencyBooking/index.tsx
+++ b/frontend/client/src/components/EmergencyBooking/index.tsx
@@ -1,0 +1,49 @@
+"use client";
+import React, { useState } from 'react'
+import { SmartLoadingState } from '../app/components/SmartLoadingState'
+import { useEmergencyService } from '../../hooks/useEmergencyService'
+
+export default function EmergencyBooking() {
+  const { requestAssist } = useEmergencyService()
+  const [description, setDescription] = useState('')
+  const [location, setLocation] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await requestAssist.mutateAsync({ description, location })
+    setDescription('')
+    setLocation('')
+  }
+
+  return (
+    <SmartLoadingState
+      isLoading={requestAssist.isLoading}
+      error={requestAssist.error as Error | null}
+      isRateLimited={false}
+      rateLimitInfo={null}
+    >
+      <form onSubmit={handleSubmit} className="space-y-4 p-4 max-w-md mx-auto">
+        <input
+          className="w-full border rounded p-2"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="Opis problemu"
+          required
+        />
+        <input
+          className="w-full border rounded p-2"
+          value={location}
+          onChange={e => setLocation(e.target.value)}
+          placeholder="Lokalizacja"
+          required
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded w-full"
+        >
+          Wezwij pomoc
+        </button>
+      </form>
+    </SmartLoadingState>
+  )
+}

--- a/frontend/client/src/components/ServiceHealthStatus/index.tsx
+++ b/frontend/client/src/components/ServiceHealthStatus/index.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React from 'react'
+import { Loader2, CheckCircle, AlertTriangle } from 'lucide-react'
+import { useMicroserviceHealth } from '../../hooks/useMicroserviceHealth'
+
+interface Props {
+  service: string
+}
+
+export default function ServiceHealthStatus({ service }: Props) {
+  const { data, isLoading } = useMicroserviceHealth(service)
+
+  if (isLoading) {
+    return <Loader2 className="h-4 w-4 animate-spin text-gray-500" />
+  }
+
+  return (
+    <div className="inline-flex items-center space-x-1">
+      {data ? (
+        <CheckCircle className="h-4 w-4 text-green-600" />
+      ) : (
+        <AlertTriangle className="h-4 w-4 text-red-600" />
+      )}
+      <span className="text-sm">{service}</span>
+    </div>
+  )
+}

--- a/frontend/client/src/hooks/useEmergencyService.ts
+++ b/frontend/client/src/hooks/useEmergencyService.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import apiClient from '../api/axiosConfig'
+
+type EmergencyRequest = {
+  description: string
+  location: string
+}
+
+export const useEmergencyService = () => {
+  const operators = useQuery(['emergency-operators'], async () => {
+    const res = await apiClient.get('/api/emergency/operators')
+    return res.data as any[]
+  })
+
+  const requestAssist = useMutation((payload: EmergencyRequest) =>
+    apiClient.post('/api/emergency/requests', payload)
+  )
+
+  return { operators, requestAssist }
+}

--- a/frontend/client/src/hooks/useMicroserviceHealth.ts
+++ b/frontend/client/src/hooks/useMicroserviceHealth.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '../api/axiosConfig'
+
+export const useMicroserviceHealth = (service: string) =>
+  useQuery(['service-health', service], async () => {
+    try {
+      await apiClient.get(`/api/${service}/health`)
+      return true
+    } catch {
+      return false
+    }
+  }, { retry: false })

--- a/frontend/client/src/pages/api/emergency/[...params].ts
+++ b/frontend/client/src/pages/api/emergency/[...params].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/emergency/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}

--- a/frontend/client/src/pages/api/workshops/[...params].ts
+++ b/frontend/client/src/pages/api/workshops/[...params].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/workshops/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}


### PR DESCRIPTION
## Summary
- proxy workshop and emergency traffic through Next.js API routes
- configure axios clients to use gateway URL
- add microservice client with health checks
- introduce emergency hooks and health hooks
- create EmergencyBooking and ServiceHealthStatus components

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test --silent` in `frontend/admin` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee05902c08327af23d902e2c24c94