### PR TITLE
Add rental service with basic vehicle management

### DIFF
--- a/src/WorkshopBooker.Api/Controllers/RentalController.cs
+++ b/src/WorkshopBooker.Api/Controllers/RentalController.cs
@@ -1,0 +1,62 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using WorkshopBooker.Application.Rentals.Commands.CreateVehicle;
+using WorkshopBooker.Application.Rentals.Commands.UpdateVehicleLocation;
+using WorkshopBooker.Application.Rentals.Commands.CreateRentalReservation;
+using WorkshopBooker.Application.Rentals.Queries.GetAvailableVehicles;
+
+namespace WorkshopBooker.Api.Controllers;
+
+[ApiController]
+[Route("api/rentals")]
+public class RentalController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    public RentalController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    [HttpPost("vehicles")]
+    [Authorize]
+    [EnableRateLimiting("WritePolicy")]
+    public async Task<IActionResult> CreateVehicle(CreateVehicleCommand command)
+    {
+        var id = await _sender.Send(command);
+        return CreatedAtAction(nameof(GetAvailableVehicles), new { id }, id);
+    }
+
+    [HttpPost("vehicles/{vehicleId}/location")]
+    [Authorize]
+    [EnableRateLimiting("WritePolicy")]
+    public async Task<IActionResult> UpdateLocation(Guid vehicleId, UpdateVehicleLocationCommand command)
+    {
+        var full = command with { VehicleId = vehicleId };
+        await _sender.Send(full);
+        return NoContent();
+    }
+
+    [HttpGet("vehicles/available")]
+    [EnableRateLimiting("ReadPolicy")]
+    public async Task<IActionResult> GetAvailableVehicles()
+    {
+        var vehicles = await _sender.Send(new GetAvailableVehiclesQuery());
+        return Ok(vehicles);
+    }
+
+    [HttpPost("reservations")]
+    [Authorize]
+    [EnableRateLimiting("CriticalPolicy")]
+    public async Task<IActionResult> CreateReservation(CreateRentalReservationCommand command)
+    {
+        var result = await _sender.Send(command);
+        if (!result.IsSuccess)
+        {
+            return BadRequest(new { error = result.Error });
+        }
+        return CreatedAtAction(nameof(CreateReservation), new { id = result.Value }, result.Value);
+    }
+}

--- a/src/WorkshopBooker.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/WorkshopBooker.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -14,6 +14,8 @@ public interface IApplicationDbContext
     DbSet<AvailableSlot> AvailableSlots { get; }
     DbSet<User> Users { get; }
     DbSet<Review> Reviews { get; }
+    DbSet<Vehicle> Vehicles { get; }
+    DbSet<RentalReservation> RentalReservations { get; }
     DatabaseFacade Database { get; }
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/WorkshopBooker.Application/Common/Interfaces/ILocationService.cs
+++ b/src/WorkshopBooker.Application/Common/Interfaces/ILocationService.cs
@@ -1,0 +1,6 @@
+namespace WorkshopBooker.Application.Common.Interfaces;
+
+public interface ILocationService
+{
+    Task<string?> GetLocationAsync(string address, CancellationToken cancellationToken);
+}

--- a/src/WorkshopBooker.Application/Rentals/Commands/CreateRentalReservation/CreateRentalReservationCommand.cs
+++ b/src/WorkshopBooker.Application/Rentals/Commands/CreateRentalReservation/CreateRentalReservationCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using WorkshopBooker.Application.Common;
+
+namespace WorkshopBooker.Application.Rentals.Commands.CreateRentalReservation;
+
+public record CreateRentalReservationCommand(
+    Guid VehicleId,
+    DateTime StartDate,
+    DateTime EndDate
+) : IRequest<Result<Guid>>;

--- a/src/WorkshopBooker.Application/Rentals/Commands/CreateRentalReservation/CreateRentalReservationCommandHandler.cs
+++ b/src/WorkshopBooker.Application/Rentals/Commands/CreateRentalReservation/CreateRentalReservationCommandHandler.cs
@@ -1,0 +1,42 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WorkshopBooker.Application.Common;
+using WorkshopBooker.Application.Common.Interfaces;
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Rentals.Commands.CreateRentalReservation;
+
+public class CreateRentalReservationCommandHandler : IRequestHandler<CreateRentalReservationCommand, Result<Guid>>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserProvider _currentUserProvider;
+
+    public CreateRentalReservationCommandHandler(IApplicationDbContext context, ICurrentUserProvider currentUserProvider)
+    {
+        _context = context;
+        _currentUserProvider = currentUserProvider;
+    }
+
+    public async Task<Result<Guid>> Handle(CreateRentalReservationCommand request, CancellationToken cancellationToken)
+    {
+        var userId = _currentUserProvider.UserId;
+        if (userId is null)
+        {
+            return Result<Guid>.Failure("User must be authenticated");
+        }
+
+        var vehicle = await _context.Vehicles.FirstOrDefaultAsync(v => v.Id == request.VehicleId, cancellationToken);
+        if (vehicle == null || vehicle.Status != VehicleStatus.Available)
+        {
+            return Result<Guid>.Failure("Vehicle not available");
+        }
+
+        vehicle.SetStatus(VehicleStatus.Rented);
+
+        var reservation = new RentalReservation(Guid.NewGuid(), request.VehicleId, userId.Value, request.StartDate, request.EndDate);
+        _context.RentalReservations.Add(reservation);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(reservation.Id);
+    }
+}

--- a/src/WorkshopBooker.Application/Rentals/Commands/CreateVehicle/CreateVehicleCommand.cs
+++ b/src/WorkshopBooker.Application/Rentals/Commands/CreateVehicle/CreateVehicleCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+
+namespace WorkshopBooker.Application.Rentals.Commands.CreateVehicle;
+
+public record CreateVehicleCommand(
+    string Make,
+    string Model,
+    string LicensePlate,
+    int Year,
+    string? Location = null
+) : IRequest<Guid>;

--- a/src/WorkshopBooker.Application/Rentals/Commands/CreateVehicle/CreateVehicleCommandHandler.cs
+++ b/src/WorkshopBooker.Application/Rentals/Commands/CreateVehicle/CreateVehicleCommandHandler.cs
@@ -1,0 +1,32 @@
+using MediatR;
+using WorkshopBooker.Application.Common.Interfaces;
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Rentals.Commands.CreateVehicle;
+
+public class CreateVehicleCommandHandler : IRequestHandler<CreateVehicleCommand, Guid>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ILocationService _locationService;
+
+    public CreateVehicleCommandHandler(IApplicationDbContext context, ILocationService locationService)
+    {
+        _context = context;
+        _locationService = locationService;
+    }
+
+    public async Task<Guid> Handle(CreateVehicleCommand request, CancellationToken cancellationToken)
+    {
+        var vehicle = new Vehicle(Guid.NewGuid(), request.Make, request.Model, request.LicensePlate, request.Year, request.Location);
+
+        if (!string.IsNullOrWhiteSpace(request.Location))
+        {
+            vehicle.UpdateLocation(await _locationService.GetLocationAsync(request.Location, cancellationToken));
+        }
+
+        _context.Vehicles.Add(vehicle);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return vehicle.Id;
+    }
+}

--- a/src/WorkshopBooker.Application/Rentals/Commands/UpdateVehicleLocation/UpdateVehicleLocationCommand.cs
+++ b/src/WorkshopBooker.Application/Rentals/Commands/UpdateVehicleLocation/UpdateVehicleLocationCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace WorkshopBooker.Application.Rentals.Commands.UpdateVehicleLocation;
+
+public record UpdateVehicleLocationCommand(Guid VehicleId, string? Location) : IRequest;

--- a/src/WorkshopBooker.Application/Rentals/Commands/UpdateVehicleLocation/UpdateVehicleLocationCommandHandler.cs
+++ b/src/WorkshopBooker.Application/Rentals/Commands/UpdateVehicleLocation/UpdateVehicleLocationCommandHandler.cs
@@ -1,0 +1,32 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WorkshopBooker.Application.Common.Interfaces;
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Rentals.Commands.UpdateVehicleLocation;
+
+public class UpdateVehicleLocationCommandHandler : IRequestHandler<UpdateVehicleLocationCommand>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ILocationService _locationService;
+
+    public UpdateVehicleLocationCommandHandler(IApplicationDbContext context, ILocationService locationService)
+    {
+        _context = context;
+        _locationService = locationService;
+    }
+
+    public async Task Handle(UpdateVehicleLocationCommand request, CancellationToken cancellationToken)
+    {
+        var vehicle = await _context.Vehicles.FirstOrDefaultAsync(v => v.Id == request.VehicleId, cancellationToken);
+        if (vehicle == null)
+        {
+            return;
+        }
+
+        var location = request.Location != null ? await _locationService.GetLocationAsync(request.Location, cancellationToken) : null;
+        vehicle.UpdateLocation(location);
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/WorkshopBooker.Application/Rentals/Dtos/RentalReservationDto.cs
+++ b/src/WorkshopBooker.Application/Rentals/Dtos/RentalReservationDto.cs
@@ -1,0 +1,13 @@
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Rentals.Dtos;
+
+public record RentalReservationDto
+{
+    public Guid Id { get; init; }
+    public Guid VehicleId { get; init; }
+    public Guid UserId { get; init; }
+    public DateTime StartDate { get; init; }
+    public DateTime EndDate { get; init; }
+    public ReservationStatus Status { get; init; }
+}

--- a/src/WorkshopBooker.Application/Rentals/Dtos/VehicleDto.cs
+++ b/src/WorkshopBooker.Application/Rentals/Dtos/VehicleDto.cs
@@ -1,0 +1,14 @@
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Rentals.Dtos;
+
+public record VehicleDto
+{
+    public Guid Id { get; init; }
+    public required string Make { get; init; }
+    public required string Model { get; init; }
+    public required string LicensePlate { get; init; }
+    public int Year { get; init; }
+    public bool IsAvailable { get; init; }
+    public string? CurrentLocation { get; init; }
+}

--- a/src/WorkshopBooker.Application/Rentals/Queries/GetAvailableVehicles/GetAvailableVehiclesQuery.cs
+++ b/src/WorkshopBooker.Application/Rentals/Queries/GetAvailableVehicles/GetAvailableVehiclesQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WorkshopBooker.Application.Rentals.Dtos;
+
+namespace WorkshopBooker.Application.Rentals.Queries.GetAvailableVehicles;
+
+public record GetAvailableVehiclesQuery : IRequest<List<VehicleDto>>;

--- a/src/WorkshopBooker.Application/Rentals/Queries/GetAvailableVehicles/GetAvailableVehiclesQueryHandler.cs
+++ b/src/WorkshopBooker.Application/Rentals/Queries/GetAvailableVehicles/GetAvailableVehiclesQueryHandler.cs
@@ -1,0 +1,34 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WorkshopBooker.Application.Common.Interfaces;
+using WorkshopBooker.Application.Rentals.Dtos;
+using WorkshopBooker.Domain.Entities;
+
+namespace WorkshopBooker.Application.Rentals.Queries.GetAvailableVehicles;
+
+public class GetAvailableVehiclesQueryHandler : IRequestHandler<GetAvailableVehiclesQuery, List<VehicleDto>>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetAvailableVehiclesQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<VehicleDto>> Handle(GetAvailableVehiclesQuery request, CancellationToken cancellationToken)
+    {
+        return await _context.Vehicles
+            .Where(v => v.Status == VehicleStatus.Available)
+            .Select(v => new VehicleDto
+            {
+                Id = v.Id,
+                Make = v.Make,
+                Model = v.Model,
+                LicensePlate = v.LicensePlate,
+                Year = v.Year,
+                IsAvailable = true,
+                CurrentLocation = v.CurrentLocation
+            })
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/WorkshopBooker.Domain/Entities/RentalReservation.cs
+++ b/src/WorkshopBooker.Domain/Entities/RentalReservation.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace WorkshopBooker.Domain.Entities;
+
+public enum ReservationStatus
+{
+    Reserved,
+    Cancelled,
+    Completed
+}
+
+public class RentalReservation
+{
+    public Guid Id { get; private set; }
+    public Guid VehicleId { get; private set; }
+    public Vehicle Vehicle { get; private set; } = null!;
+    public Guid UserId { get; private set; }
+    public User User { get; private set; } = null!;
+    public DateTime StartDate { get; private set; }
+    public DateTime EndDate { get; private set; }
+    public ReservationStatus Status { get; private set; }
+
+    private RentalReservation() { }
+
+    public RentalReservation(Guid id, Guid vehicleId, Guid userId, DateTime startDate, DateTime endDate)
+    {
+        Id = id;
+        VehicleId = vehicleId;
+        UserId = userId;
+        StartDate = startDate;
+        EndDate = endDate;
+        Status = ReservationStatus.Reserved;
+    }
+
+    public void Cancel()
+    {
+        Status = ReservationStatus.Cancelled;
+    }
+
+    public void Complete()
+    {
+        Status = ReservationStatus.Completed;
+    }
+}

--- a/src/WorkshopBooker.Domain/Entities/Vehicle.cs
+++ b/src/WorkshopBooker.Domain/Entities/Vehicle.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace WorkshopBooker.Domain.Entities;
+
+public enum VehicleStatus
+{
+    Available,
+    Rented,
+    Maintenance
+}
+
+public class Vehicle
+{
+    public Guid Id { get; private set; }
+    public string Make { get; private set; } = null!;
+    public string Model { get; private set; } = null!;
+    public string LicensePlate { get; private set; } = null!;
+    public int Year { get; private set; }
+    public VehicleStatus Status { get; private set; }
+    public string? CurrentLocation { get; private set; }
+
+    public Guid? WorkshopId { get; private set; }
+    public Workshop? Workshop { get; private set; }
+
+    private Vehicle() { }
+
+    public Vehicle(Guid id, string make, string model, string licensePlate, int year, string? currentLocation = null, Guid? workshopId = null)
+    {
+        Id = id;
+        Make = make;
+        Model = model;
+        LicensePlate = licensePlate;
+        Year = year;
+        Status = VehicleStatus.Available;
+        CurrentLocation = currentLocation;
+        WorkshopId = workshopId;
+    }
+
+    public void UpdateLocation(string? location)
+    {
+        CurrentLocation = location;
+    }
+
+    public void SetStatus(VehicleStatus status)
+    {
+        Status = status;
+    }
+}

--- a/src/WorkshopBooker.Infrastructure/DependencyInjection.cs
+++ b/src/WorkshopBooker.Infrastructure/DependencyInjection.cs
@@ -16,6 +16,7 @@ public static class DependencyInjection
         services.AddScoped<IEmailService, SendGridEmailService>();
         services.AddScoped<ISmsService, TwilioSmsService>();
         services.AddScoped<INotificationService, NotificationService>();
+        services.AddHttpClient<ILocationService, LocationService>();
         
         // ✅ POPRAWKA: Rejestracja jako singleton z proper disposal
         services.AddSingleton<IBackgroundJobService, BackgroundJobService>();

--- a/src/WorkshopBooker.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/WorkshopBooker.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -16,6 +16,8 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<AvailableSlot> AvailableSlots { get; set; }
     public DbSet<User> Users { get; set; }
     public DbSet<Review> Reviews { get; set; }
+    public DbSet<Vehicle> Vehicles { get; set; }
+    public DbSet<RentalReservation> RentalReservations { get; set; }
     
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
@@ -107,6 +109,33 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        // Konfiguracja Vehicle
+        modelBuilder.Entity<Vehicle>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Make).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.Model).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.LicensePlate).IsRequired().HasMaxLength(20);
+        });
+
+        // Konfiguracja RentalReservation
+        modelBuilder.Entity<RentalReservation>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.StartDate).IsRequired();
+            entity.Property(e => e.EndDate).IsRequired();
+
+            entity.HasOne(e => e.Vehicle)
+                .WithMany()
+                .HasForeignKey(e => e.VehicleId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
         // Indeksy dla lepszej wydajności
         modelBuilder.Entity<Workshop>()
             .HasIndex(e => e.Name);
@@ -138,5 +167,11 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
         modelBuilder.Entity<Review>()
             .HasIndex(e => e.BookingId)
             .IsUnique();
+
+        modelBuilder.Entity<Vehicle>()
+            .HasIndex(e => e.Status);
+
+        modelBuilder.Entity<RentalReservation>()
+            .HasIndex(e => new { e.VehicleId, e.StartDate });
     }
 }

--- a/src/WorkshopBooker.Infrastructure/Services/LocationService.cs
+++ b/src/WorkshopBooker.Infrastructure/Services/LocationService.cs
@@ -1,0 +1,20 @@
+using WorkshopBooker.Application.Common.Interfaces;
+
+namespace WorkshopBooker.Infrastructure.Services;
+
+public class LocationService : ILocationService
+{
+    private readonly HttpClient _httpClient;
+
+    public LocationService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<string?> GetLocationAsync(string address, CancellationToken cancellationToken)
+    {
+        // Placeholder implementation - in real scenario we would call external geocoding API
+        await Task.Delay(50, cancellationToken);
+        return address;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce Vehicle and RentalReservation domain models
- extend ApplicationDbContext with rental DbSets and configure new entities
- provide location service and register via DI
- add commands/queries/DTOs for rental management
- expose RentalController endpoints for vehicles and reservations

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee0d797d48327badfc086731816ad