### PR TITLE
Integrate microservices across stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,33 +46,23 @@ services:
       postgres:
         condition: service_healthy
 
-  emergency-service:
+  api-gateway:
     image: mcr.microsoft.com/dotnet/sdk:8.0
-    container_name: emergency-service
+    container_name: api-gateway
     working_dir: /src
-    command: ["dotnet", "run", "--urls", "http://0.0.0.0:80", "--project", "WorkshopBooker.Api/WorkshopBooker.Api.csproj"]
+    command: ["dotnet", "run", "--urls", "http://0.0.0.0:80", "--project", "Gateway/WorkshopBooker.Gateway/WorkshopBooker.Gateway.csproj"]
     volumes:
       - ./src:/src
-    environment:
-      ASPNETCORE_ENVIRONMENT: Development
-      ConnectionStrings__DefaultConnection: Server=postgres;Port=5432;Database=EmergencyDb;User Id=postgres;Password=twoje_haslo;
     ports:
-      - "5001:80"
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  api-gateway:
-    image: nginx:alpine
-    container_name: api-gateway
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-    ports:
-      - "8088:80"
+      - "5000:80"
     depends_on:
       workshop-service:
         condition: service_started
       emergency-service:
+        condition: service_started
+      insurance-service:
+        condition: service_started
+      legal-service:
         condition: service_started
 
   web-app:
@@ -83,7 +73,8 @@ services:
     volumes:
       - ./frontend/client:/app
     environment:
-      NEXT_PUBLIC_API_URL: http://api-gateway
+      API_GATEWAY_URL: http://api-gateway:80
+      NEXT_PUBLIC_API_GATEWAY_URL: http://api-gateway:80
     ports:
       - "3000:3000"
     depends_on:
@@ -116,6 +107,24 @@ services:
       - ASPNETCORE_URLS=http://0.0.0.0:5001
     depends_on:
       - emergency-db
+
+  insurance-service:
+    build: ./src/Services/Insurance/WorkshopBooker.Insurance.Api
+    ports:
+      - "5002:5002"
+    environment:
+      - ASPNETCORE_URLS=http://0.0.0.0:5002
+    depends_on:
+      - workshop-service
+
+  legal-service:
+    build: ./src/Services/Legal/WorkshopBooker.Legal.Api
+    ports:
+      - "5003:5003"
+    environment:
+      - ASPNETCORE_URLS=http://0.0.0.0:5003
+    depends_on:
+      - workshop-service
 
 volumes:
   postgres_data:

--- a/frontend/admin/src/pages/api/insurance/[...params].ts
+++ b/frontend/admin/src/pages/api/insurance/[...params].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/insurance/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}

--- a/frontend/admin/src/pages/api/legal/[...params].ts
+++ b/frontend/admin/src/pages/api/legal/[...params].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/legal/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}

--- a/frontend/client/src/pages/api/insurance/[...params].ts
+++ b/frontend/client/src/pages/api/insurance/[...params].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/insurance/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}

--- a/frontend/client/src/pages/api/legal/[...params].ts
+++ b/frontend/client/src/pages/api/legal/[...params].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const gatewayUrl = process.env.API_GATEWAY_URL || 'http://localhost:5000'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { params = [] } = req.query as { params?: string[] }
+  const target = `${gatewayUrl}/api/legal/${params.join('/')}`
+
+  try {
+    const fetchRes = await fetch(target, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers as any) },
+      body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : JSON.stringify(req.body)
+    })
+    const data = await fetchRes.text()
+    res.status(fetchRes.status).send(data)
+  } catch (err) {
+    console.error('Gateway request failed', err)
+    res.status(502).json({ message: 'Gateway unavailable' })
+  }
+}

--- a/k8s/insurance-service-deployment.yml
+++ b/k8s/insurance-service-deployment.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insurance-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: insurance-service
+  template:
+    metadata:
+      labels:
+        app: insurance-service
+    spec:
+      containers:
+        - name: insurance-service
+          image: ghcr.io/workshopbooker/insurance-service:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Production

--- a/k8s/legal-service-deployment.yml
+++ b/k8s/legal-service-deployment.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: legal-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: legal-service
+  template:
+    metadata:
+      labels:
+        app: legal-service
+    spec:
+      containers:
+        - name: legal-service
+          image: ghcr.io/workshopbooker/legal-service:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Production

--- a/k8s/services.yml
+++ b/k8s/services.yml
@@ -23,6 +23,28 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: insurance-service
+spec:
+  selector:
+    app: insurance-service
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: legal-service
+spec:
+  selector:
+    app: legal-service
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: workshop-service
 spec:
   selector:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -7,4 +7,10 @@ scrape_configs:
       - targets: ['workshop-service:80']
   - job_name: 'emergency-service'
     static_configs:
-      - targets: ['emergency-service:80']
+      - targets: ['emergency-service:5001']
+  - job_name: 'insurance-service'
+    static_configs:
+      - targets: ['insurance-service:5002']
+  - job_name: 'legal-service'
+    static_configs:
+      - targets: ['legal-service:5003']

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -4,4 +4,6 @@ set -e
 kubectl apply -f k8s/services.yml
 kubectl apply -f k8s/api-gateway-deployment.yml
 kubectl apply -f k8s/emergency-service-deployment.yml
+kubectl apply -f k8s/insurance-service-deployment.yml
+kubectl apply -f k8s/legal-service-deployment.yml
 kubectl apply -f k8s/ingress.yml

--- a/src/Gateway/WorkshopBooker.Gateway/ocelot.json
+++ b/src/Gateway/WorkshopBooker.Gateway/ocelot.json
@@ -5,11 +5,47 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "api",
+          "Host": "workshop-service",
           "Port": 80
         }
       ],
       "UpstreamPathTemplate": "/api/{everything}",
+      "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"]
+    },
+    {
+      "DownstreamPathTemplate": "/api/emergency/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "emergency-service",
+          "Port": 5001
+        }
+      ],
+      "UpstreamPathTemplate": "/api/emergency/{everything}",
+      "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"]
+    },
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "insurance-service",
+          "Port": 5002
+        }
+      ],
+      "UpstreamPathTemplate": "/api/insurance/{everything}",
+      "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"]
+    },
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "legal-service",
+          "Port": 5003
+        }
+      ],
+      "UpstreamPathTemplate": "/api/legal/{everything}",
       "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"]
     }
   ],


### PR DESCRIPTION
## Summary
- route all microservices through API Gateway
- expose Insurance and Legal services in docker-compose
- add BFF API routes for new services
- monitor all services in Prometheus
- extend Kubernetes manifests and deploy script

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` in `frontend/admin` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f552e43c48327be397f1ed1920f60