### PR TITLE
Integrate gateway routes

### DIFF
--- a/src/Gateway/WorkshopBooker.Gateway/ocelot.json
+++ b/src/Gateway/WorkshopBooker.Gateway/ocelot.json
@@ -1,18 +1,6 @@
 {
   "Routes": [
     {
-      "DownstreamPathTemplate": "/api/{everything}",
-      "DownstreamScheme": "http",
-      "DownstreamHostAndPorts": [
-        {
-          "Host": "workshop-service",
-          "Port": 80
-        }
-      ],
-      "UpstreamPathTemplate": "/api/{everything}",
-      "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"]
-    },
-    {
       "DownstreamPathTemplate": "/api/emergency/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
@@ -47,6 +35,19 @@
       ],
       "UpstreamPathTemplate": "/api/legal/{everything}",
       "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"]
+    },
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "workshop-service",
+          "Port": 80
+        }
+      ],
+      "UpstreamPathTemplate": "/api/{everything}",
+      "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"],
+      "Priority": 99
     }
   ],
   "GlobalConfiguration": {


### PR DESCRIPTION
## Summary
- adjust Ocelot route order so specific microservices are matched before the main API

## Testing
- `npm install` in `frontend/client`
- `npm test` in `frontend/admin` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5ad54ef08327afeeaf70b53c7279